### PR TITLE
Add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "layervault",
   "version": "0.1.2",
   "description": "LayerVault API client",
+  "main": "lib/layervault.js",
   "keywords": [
     "layervault",
     "design",


### PR DESCRIPTION
Without the [main](https://www.npmjs.org/doc/json.html#main) field in the `package.json` file, `require('layervault')` fails when the library is installed via npm.
